### PR TITLE
add TRAPI yaml to output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ RUN mkdir /work /app
 WORKDIR /work
 RUN git clone https://github.com/NCATSTranslator/ReasonerAPI.git ./ReasonerAPI.git
 
-CMD ["fastapi-codegen", "--input", "/work/ReasonerAPI.git/TranslatorReasonerAPI.yaml", "--output", "/app"]
+COPY main.sh /work
+RUN chmod 755 /work/main.sh
+
+CMD ["/work/main.sh"]

--- a/main.sh
+++ b/main.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+### copy the TRAPI yaml file to the output directory
+cp /work/ReasonerAPI.git/TranslatorReasonerAPI.yaml /app
+
+### generate FastAPI stub files
+fastapi-codegen --input /work/ReasonerAPI.git/TranslatorReasonerAPI.yaml --output /app


### PR DESCRIPTION
Add a script that copies the TRAPI yaml file to the output directory prior to generating the FastAPI stub files.